### PR TITLE
Fix C++11 exception handling in destructors

### DIFF
--- a/sqlitepp/config.hpp
+++ b/sqlitepp/config.hpp
@@ -1,0 +1,22 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2018 Pavel Medvedev
+// Use, modification and distribution is subject to the
+// Boost Software License, Version 1.0. (See accompanying file
+// LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef SQLITEPP_CONFIG_HPP_INCLUDED
+#define SQLITEPP_CONFIG_HPP_INCLUDED
+
+// In C++11 default behavior when throwing an exception in destructors has
+// changed. Default for all destructors is noexcept, which means the
+// program will be immediately terminated when an exception in a destructor
+// is thrown. To change this behavior to allow throwing catchable
+// exceptions in a destructor we add the noexcept(false) specifier.  
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
+#define NOEXCEPT_FALSE  noexcept(false)
+#else
+#define NOEXCEPT_FALSE
+#endif
+
+#endif // SQLITEPP_CONFIG_HPP_INCLUDED

--- a/sqlitepp/query.cpp
+++ b/sqlitepp/query.cpp
@@ -157,7 +157,7 @@ prepare_query::prepare_query(prepare_query& src)
 //----------------------------------------------------------------------------
 
 prepare_query::~prepare_query()
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
           noexcept(false)
 #endif
 {
@@ -189,7 +189,7 @@ once_query::once_query(once_query& src)
 //----------------------------------------------------------------------------
 
 once_query::~once_query()
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
           noexcept(false)
 #endif
 {

--- a/sqlitepp/query.cpp
+++ b/sqlitepp/query.cpp
@@ -156,10 +156,7 @@ prepare_query::prepare_query(prepare_query& src)
 }
 //----------------------------------------------------------------------------
 
-prepare_query::~prepare_query()
-#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
-          noexcept(false)
-#endif
+prepare_query::~prepare_query() NOEXCEPT_FALSE
 {
 	if ( st_ )
 	{
@@ -188,10 +185,7 @@ once_query::once_query(once_query& src)
 }
 //----------------------------------------------------------------------------
 
-once_query::~once_query()
-#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
-          noexcept(false)
-#endif
+once_query::~once_query() NOEXCEPT_FALSE
 {
 	if ( s_ )
 	{

--- a/sqlitepp/query.cpp
+++ b/sqlitepp/query.cpp
@@ -157,6 +157,9 @@ prepare_query::prepare_query(prepare_query& src)
 //----------------------------------------------------------------------------
 
 prepare_query::~prepare_query()
+#if __cplusplus >= 201103L
+          noexcept(false)
+#endif
 {
 	if ( st_ )
 	{
@@ -186,6 +189,9 @@ once_query::once_query(once_query& src)
 //----------------------------------------------------------------------------
 
 once_query::~once_query()
+#if __cplusplus >= 201103L
+          noexcept(false)
+#endif
 {
 	if ( s_ )
 	{

--- a/sqlitepp/query.hpp
+++ b/sqlitepp/query.hpp
@@ -12,6 +12,7 @@
 #include <sstream>
 #include <memory>
 
+#include "config.hpp"
 #include "string.hpp"
 #include "binders.hpp"
 
@@ -122,11 +123,7 @@ public:
 	prepare_query(prepare_query& src);
 
 	// Move query to statement on destroy.
-	~prepare_query()
-#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
-          noexcept(false)
-#endif
-          ;
+	~prepare_query() NOEXCEPT_FALSE;
 private:
 	// Create preparing proxy for statement.
 	prepare_query(statement& st);
@@ -146,11 +143,7 @@ public:
 	once_query(once_query& src);
 
 	// Execute statement on destroy.
-	~once_query()
-#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
-          noexcept(false)
-#endif
-          ;
+	~once_query() NOEXCEPT_FALSE;
 private:
 	// Create proxy for session.
 	once_query(session& s);

--- a/sqlitepp/query.hpp
+++ b/sqlitepp/query.hpp
@@ -122,7 +122,11 @@ public:
 	prepare_query(prepare_query& src);
 
 	// Move query to statement on destroy.
-	~prepare_query();
+	~prepare_query()
+#if __cplusplus >= 201103L
+          noexcept(false)
+#endif
+          ;
 private:
 	// Create preparing proxy for statement.
 	prepare_query(statement& st);
@@ -142,7 +146,11 @@ public:
 	once_query(once_query& src);
 
 	// Execute statement on destroy.
-	~once_query();
+	~once_query()
+#if __cplusplus >= 201103L
+          noexcept(false)
+#endif
+          ;
 private:
 	// Create proxy for session.
 	once_query(session& s);

--- a/sqlitepp/query.hpp
+++ b/sqlitepp/query.hpp
@@ -123,7 +123,7 @@ public:
 
 	// Move query to statement on destroy.
 	~prepare_query()
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
           noexcept(false)
 #endif
           ;
@@ -147,7 +147,7 @@ public:
 
 	// Execute statement on destroy.
 	~once_query()
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
           noexcept(false)
 #endif
           ;

--- a/sqlitepp/session.cpp
+++ b/sqlitepp/session.cpp
@@ -55,10 +55,7 @@ session::session(string_t const& file_name, int flags)
 }
 //----------------------------------------------------------------------------
 
-session::~session()
-#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
-          noexcept(false)
-#endif
+session::~session() NOEXCEPT_FALSE
 {
 	try
 	{

--- a/sqlitepp/session.cpp
+++ b/sqlitepp/session.cpp
@@ -56,6 +56,9 @@ session::session(string_t const& file_name, int flags)
 //----------------------------------------------------------------------------
 
 session::~session()
+#if __cplusplus >= 201103L
+          noexcept(false)
+#endif
 {
 	try
 	{

--- a/sqlitepp/session.cpp
+++ b/sqlitepp/session.cpp
@@ -56,7 +56,7 @@ session::session(string_t const& file_name, int flags)
 //----------------------------------------------------------------------------
 
 session::~session()
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
           noexcept(false)
 #endif
 {

--- a/sqlitepp/session.hpp
+++ b/sqlitepp/session.hpp
@@ -37,7 +37,7 @@ public:
 	
 	// Close session on destroy.
 	~session()
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
           noexcept(false)
 #endif
           ;

--- a/sqlitepp/session.hpp
+++ b/sqlitepp/session.hpp
@@ -36,11 +36,7 @@ public:
 	explicit session(string_t const& file_name, int flags = 0);
 	
 	// Close session on destroy.
-	~session()
-#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
-          noexcept(false)
-#endif
-          ;
+	~session() NOEXCEPT_FALSE;
 
 	// Open database session. Previous one will be closed.
 	// Optional parameter flags for file open operations

--- a/sqlitepp/session.hpp
+++ b/sqlitepp/session.hpp
@@ -36,7 +36,11 @@ public:
 	explicit session(string_t const& file_name, int flags = 0);
 	
 	// Close session on destroy.
-	~session();
+	~session()
+#if __cplusplus >= 201103L
+          noexcept(false)
+#endif
+          ;
 
 	// Open database session. Previous one will be closed.
 	// Optional parameter flags for file open operations

--- a/sqlitepp/statement.cpp
+++ b/sqlitepp/statement.cpp
@@ -89,10 +89,7 @@ statement::statement(session& s, string_t const& sql)
 }
 //----------------------------------------------------------------------------
 
-statement::~statement()
-#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
-          noexcept(false)
-#endif
+statement::~statement() NOEXCEPT_FALSE
 {
 	finalize(false);
 }

--- a/sqlitepp/statement.cpp
+++ b/sqlitepp/statement.cpp
@@ -90,6 +90,9 @@ statement::statement(session& s, string_t const& sql)
 //----------------------------------------------------------------------------
 
 statement::~statement()
+#if __cplusplus >= 201103L
+          noexcept(false)
+#endif
 {
 	finalize(false);
 }

--- a/sqlitepp/statement.cpp
+++ b/sqlitepp/statement.cpp
@@ -90,7 +90,7 @@ statement::statement(session& s, string_t const& sql)
 //----------------------------------------------------------------------------
 
 statement::~statement()
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
           noexcept(false)
 #endif
 {

--- a/sqlitepp/statement.hpp
+++ b/sqlitepp/statement.hpp
@@ -36,7 +36,7 @@ public:
 
 	// Finalize statement on destroy.
 	~statement()
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
           noexcept(false)
 #endif
           ;

--- a/sqlitepp/statement.hpp
+++ b/sqlitepp/statement.hpp
@@ -35,7 +35,11 @@ public:
 	statement(session& s, string_t const& sql);
 
 	// Finalize statement on destroy.
-	~statement();
+	~statement()
+#if __cplusplus >= 201103L
+          noexcept(false)
+#endif
+          ;
 
 	// Execute statement. Return true if result exists.
 	bool exec();

--- a/sqlitepp/statement.hpp
+++ b/sqlitepp/statement.hpp
@@ -35,11 +35,7 @@ public:
 	statement(session& s, string_t const& sql);
 
 	// Finalize statement on destroy.
-	~statement()
-#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
-          noexcept(false)
-#endif
-          ;
+	~statement() NOEXCEPT_FALSE;
 
 	// Execute statement. Return true if result exists.
 	bool exec();

--- a/sqlitepp/transaction.cpp
+++ b/sqlitepp/transaction.cpp
@@ -51,7 +51,7 @@ transaction::transaction(session& s, type t)
 //----------------------------------------------------------------------------
 
 transaction::~transaction()
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
           noexcept(false)
 #endif
 {

--- a/sqlitepp/transaction.cpp
+++ b/sqlitepp/transaction.cpp
@@ -51,6 +51,9 @@ transaction::transaction(session& s, type t)
 //----------------------------------------------------------------------------
 
 transaction::~transaction()
+#if __cplusplus >= 201103L
+          noexcept(false)
+#endif
 {
 	if ( do_rollback_ )
 	{

--- a/sqlitepp/transaction.cpp
+++ b/sqlitepp/transaction.cpp
@@ -50,10 +50,7 @@ transaction::transaction(session& s, type t)
 }
 //----------------------------------------------------------------------------
 
-transaction::~transaction()
-#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
-          noexcept(false)
-#endif
+transaction::~transaction() NOEXCEPT_FALSE
 {
 	if ( do_rollback_ )
 	{

--- a/sqlitepp/transaction.hpp
+++ b/sqlitepp/transaction.hpp
@@ -28,7 +28,7 @@ public:
 
 	// End transaction with rollback if it is not commited.
 	~transaction()
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
           noexcept(false)
 #endif
           ;

--- a/sqlitepp/transaction.hpp
+++ b/sqlitepp/transaction.hpp
@@ -27,7 +27,11 @@ public:
 	transaction(session& s, type t = deferred);
 
 	// End transaction with rollback if it is not commited.
-	~transaction();
+	~transaction()
+#if __cplusplus >= 201103L
+          noexcept(false)
+#endif
+          ;
 
 	// Commit transaction.
 	void commit();

--- a/sqlitepp/transaction.hpp
+++ b/sqlitepp/transaction.hpp
@@ -8,6 +8,8 @@
 #ifndef SQLITEPP_TRANSACTION_HPP_INCLUDED
 #define SQLITEPP_TRANSACTION_HPP_INCLUDED
 
+#include "config.hpp"
+
 //////////////////////////////////////////////////////////////////////////////
 
 namespace sqlitepp {
@@ -27,11 +29,7 @@ public:
 	transaction(session& s, type t = deferred);
 
 	// End transaction with rollback if it is not commited.
-	~transaction()
-#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
-          noexcept(false)
-#endif
-          ;
+	~transaction() NOEXCEPT_FALSE;
 
 	// Commit transaction.
 	void commit();


### PR DESCRIPTION
In C++11 default behavior when throwing an exception in destructors has
changed. Default for all destructors is noexcept, which means the
program will be immediately terminated when an exception in a destructor
is thrown.  To change this behavior to allow throwing catchable
exceptions in a destructor we add the noexcept(false) specifier.